### PR TITLE
Document OpenAgents Coder compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Current shipped surface:
   reconstruction after worker restart, heartbeats, approvals, transcript refs,
   artifact refs, and child-session hooks without making Codex the product
   contract
+- `docs/101-openagents-coder-runtime-adapter.md` for the OpenAgents Coder
+  compatibility note: hosted Probe remains one Coder runtime adapter behind
+  Autopilot-owned jobs, events, approvals, evidence, and receipts, while raw
+  Probe sessions, auth material, local paths, and unbounded outputs stay
+  runtime-local
 - `probe_protocol::managed_environment` plus `probe_core::managed_environment`
   for the provider-neutral managed environment contract: Pylon, Google Cloud,
   private GCE, local, and future Daytona worker advertisements, Laravel
@@ -162,6 +167,10 @@ optional Probe-selected backend behind that boundary.
 The managed runtime API is documented in `docs/94-managed-runtime-api.md`. It
 is the direct Laravel-to-Probe control surface for managed-agent sessions:
 Laravel owns product persistence and Probe owns runtime session/event truth.
+The OpenAgents Coder compatibility note is documented in
+`docs/101-openagents-coder-runtime-adapter.md`. It explains how Autopilot can
+map hosted Probe managed-runtime requests and website-safe events into
+`coder.event.v1` without receiving raw Probe internals.
 The managed environment contract is documented in
 `docs/95-managed-environment-contract.md`. It is the provider-neutral worker
 capability and constraint layer Laravel should use before dispatching managed

--- a/crates/probe-protocol/tests/coder_runtime_adapter_contract.rs
+++ b/crates/probe-protocol/tests/coder_runtime_adapter_contract.rs
@@ -1,0 +1,288 @@
+use std::path::PathBuf;
+
+use probe_protocol::backend::{BackendKind, BackendProfile, PrefixCacheMode, ServerAttachMode};
+use probe_protocol::managed_runtime::{
+    ManagedRuntimeActor, ManagedRuntimeCorrelation, ManagedRuntimeRequest,
+    ManagedRuntimeRequestEnvelope, ManagedSessionStartRequest,
+    PROBE_MANAGED_RUNTIME_SCHEMA_VERSION,
+};
+use probe_protocol::runtime::{
+    ToolApprovalRecipe, ToolChoice, ToolDeniedAction, ToolLoopRecipe, ToolSetKind,
+};
+use probe_protocol::website_events::{
+    PROBE_WEBSITE_EVENT_SCHEMA_VERSION, ProbeWebsiteArtifactKind, ProbeWebsiteArtifactRef,
+    ProbeWebsiteEvent, ProbeWebsiteEventActor, ProbeWebsiteEventBatch,
+    ProbeWebsiteEventCorrelation, ProbeWebsiteEventSource, ProbeWebsiteEventType,
+};
+use serde_json::{Map, Value, json};
+
+#[test]
+fn coder_style_start_request_stays_inside_managed_runtime_v1() {
+    let envelope = ManagedRuntimeRequestEnvelope {
+        request: ManagedRuntimeRequest::StartSession(ManagedSessionStartRequest {
+            schema_version: String::from(PROBE_MANAGED_RUNTIME_SCHEMA_VERSION),
+            request_id: String::from("coder-job-123:start"),
+            idempotency_key: String::from("coder-job-123:start:v1"),
+            actor: ManagedRuntimeActor {
+                kind: String::from("autopilot_coder"),
+                id: Some(String::from("api-key-123")),
+                label: Some(String::from("Autopilot Coder API")),
+            },
+            correlation: ManagedRuntimeCorrelation {
+                request_id: Some(String::from("coder-job-123:start")),
+                workspace: Some(String::from("autopilot3")),
+                managed_agent_id: Some(String::from("coder-deployment-456")),
+                managed_environment_id: Some(String::from("probe-worker-pool-main")),
+                managed_session_id: Some(String::from("managed-session-123")),
+                managed_run_id: Some(String::from("coder-job-123")),
+                work_order_id: Some(String::from("coder-job-123")),
+                ..ManagedRuntimeCorrelation::default()
+            },
+            title: Some(String::from("Autopilot Coder hosted Probe smoke")),
+            cwd: PathBuf::from("/workspace/repositories/autopilot3"),
+            profile: codex_backend_profile(),
+            system_prompt: Some(String::from(
+                "Act as a hosted Probe Coder runtime. Return website-safe event summaries.",
+            )),
+            harness_profile: None,
+            workspace_state: None,
+            mounted_refs: Vec::new(),
+            initial_prompt: Some(String::from(
+                "Inspect the linked repository and cite source paths without writing files.",
+            )),
+            tool_loop: Some(ToolLoopRecipe {
+                tool_set: ToolSetKind::CodingBootstrap,
+                tool_choice: ToolChoice::Auto,
+                parallel_tool_calls: false,
+                max_model_round_trips: 8,
+                approval: ToolApprovalRecipe {
+                    allow_write_tools: false,
+                    allow_network_shell: false,
+                    allow_destructive_shell: false,
+                    denied_action: ToolDeniedAction::Pause,
+                    overrides: Vec::new(),
+                },
+                oracle: None,
+                long_context: None,
+            }),
+            environment_constraints: None,
+            metadata: coder_metadata(),
+        }),
+    };
+
+    let value = serde_json::to_value(&envelope).expect("serialize managed runtime request");
+
+    assert_eq!(value["request"]["op"], "start_session");
+    assert_eq!(
+        value["request"]["schemaVersion"],
+        PROBE_MANAGED_RUNTIME_SCHEMA_VERSION
+    );
+    assert_eq!(
+        value["request"]["metadata"]["openagentsCoder"]["coderJobId"],
+        "coder-job-123"
+    );
+    assert_eq!(
+        value["request"]["correlation"]["managedRunId"],
+        "coder-job-123"
+    );
+    assert_no_secret_payload(&value);
+}
+
+#[test]
+fn website_safe_events_cover_coder_event_mapping_without_raw_probe_payloads() {
+    let batch = ProbeWebsiteEventBatch::new(vec![
+        website_event(
+            1,
+            ProbeWebsiteEventType::RunStarted,
+            json!({ "title": "Coder job started" }),
+        ),
+        website_event(
+            2,
+            ProbeWebsiteEventType::RuntimeProgress,
+            json!({ "summary": "Repository checkout completed", "sourcePaths": ["README.md"] }),
+        ),
+        website_event(
+            3,
+            ProbeWebsiteEventType::ApprovalRequested,
+            json!({
+                "approvalId": "approval-123",
+                "toolName": "shell",
+                "argumentsSummary": { "command": "git diff --check" }
+            }),
+        ),
+        website_event(
+            4,
+            ProbeWebsiteEventType::ApprovalResolved,
+            json!({ "approvalId": "approval-123", "decision": "approved" }),
+        ),
+        website_event(
+            5,
+            ProbeWebsiteEventType::ChildSessionStarted,
+            json!({ "childProbeSessionId": "sess-child-123", "purpose": "read-only research" }),
+        ),
+        website_event(
+            6,
+            ProbeWebsiteEventType::ArtifactRef,
+            json!({ "label": "Probe transcript" }),
+        )
+        .with_artifact_refs(vec![ProbeWebsiteArtifactRef {
+            kind: ProbeWebsiteArtifactKind::Transcript,
+            resource_ref: String::from("probe://sessions/sess-coder-123/transcript"),
+            stable_digest: Some(String::from("sha256-codertranscript")),
+            label: Some(String::from("Probe transcript")),
+            updated_at_ms: Some(1_777_777_777_006),
+        }]),
+        website_event(
+            7,
+            ProbeWebsiteEventType::RunCompleted,
+            json!({ "status": "completed", "summary": "Read-only inspection completed" }),
+        ),
+    ]);
+
+    assert_eq!(batch.schema_version, PROBE_WEBSITE_EVENT_SCHEMA_VERSION);
+    assert_eq!(
+        batch
+            .events
+            .iter()
+            .map(|event| coder_event_name(&event.event_type))
+            .collect::<Vec<_>>(),
+        vec![
+            "job.started",
+            "runtime.progress",
+            "approval.requested",
+            "approval.resolved",
+            "child_session.started",
+            "artifact.ref",
+            "job.completed",
+        ]
+    );
+    assert!(batch.events.iter().all(|event| event.sequence > 0));
+    assert_no_secret_payload(&serde_json::to_value(&batch).expect("serialize website events"));
+}
+
+#[test]
+fn coder_compatibility_doc_names_boundaries_and_smoke_path() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let doc =
+        std::fs::read_to_string(repo_root.join("docs/101-openagents-coder-runtime-adapter.md"))
+            .expect("read coder compatibility doc");
+
+    for required in [
+        "probe.managed_runtime.v1",
+        "probe.website_event.v1",
+        "coder.event.v1",
+        "StartSession",
+        "ResolveApproval",
+        "raw Probe transcripts",
+        "Codex subscription auth",
+        "minimal smoke path",
+        "https://github.com/OpenAgentsInc/autopilot3/issues/199",
+        "https://github.com/OpenAgentsInc/autopilot3/issues/200",
+    ] {
+        assert!(doc.contains(required), "doc missing {required}");
+    }
+}
+
+fn website_event(
+    sequence: u64,
+    event_type: ProbeWebsiteEventType,
+    payload: Value,
+) -> ProbeWebsiteEvent {
+    ProbeWebsiteEvent::new(
+        sequence,
+        1_777_777_777_000 + sequence,
+        event_type,
+        ProbeWebsiteEventActor {
+            kind: String::from("probe"),
+            id: Some(String::from("worker-probe-coder")),
+            label: Some(String::from("Hosted Probe")),
+        },
+        ProbeWebsiteEventSource {
+            kind: String::from("managed_runtime"),
+            id: Some(String::from("sess-coder-123")),
+            label: None,
+        },
+        ProbeWebsiteEventCorrelation {
+            request_id: Some(String::from("coder-job-123:start")),
+            workspace: Some(String::from("autopilot3")),
+            conversation_id: Some(String::from("thread-123")),
+            run_id: Some(String::from("coder-job-123")),
+            probe_session_id: Some(String::from("sess-coder-123")),
+            probe_turn_id: Some(String::from("turn-0")),
+            ..ProbeWebsiteEventCorrelation::default()
+        },
+        payload.as_object().cloned().unwrap_or_default(),
+    )
+}
+
+fn coder_event_name(event_type: &ProbeWebsiteEventType) -> &'static str {
+    match event_type {
+        ProbeWebsiteEventType::RunStarted => "job.started",
+        ProbeWebsiteEventType::TextDelta => "assistant.delta",
+        ProbeWebsiteEventType::ToolCallStarted => "tool.started",
+        ProbeWebsiteEventType::ToolCallCompleted => "tool.completed",
+        ProbeWebsiteEventType::ApprovalRequested => "approval.requested",
+        ProbeWebsiteEventType::ApprovalResolved => "approval.resolved",
+        ProbeWebsiteEventType::ChildSessionStarted => "child_session.started",
+        ProbeWebsiteEventType::ChildSessionUpdated => "child_session.updated",
+        ProbeWebsiteEventType::ArtifactRef => "artifact.ref",
+        ProbeWebsiteEventType::RuntimeProgress => "runtime.progress",
+        ProbeWebsiteEventType::RunCompleted => "job.completed",
+        ProbeWebsiteEventType::RunFailed => "job.failed",
+        ProbeWebsiteEventType::RunCancelled => "job.canceled",
+    }
+}
+
+fn coder_metadata() -> Map<String, Value> {
+    let mut metadata = Map::new();
+    metadata.insert(
+        String::from("openagentsCoder"),
+        json!({
+            "coderJobId": "coder-job-123",
+            "coderDeploymentId": "coder-deployment-456",
+            "coderRuntimeKind": "hosted-probe",
+            "autopilotAdapterIssue": "https://github.com/OpenAgentsInc/autopilot3/issues/199",
+            "autopilotTrackerIssue": "https://github.com/OpenAgentsInc/autopilot3/issues/200",
+            "eventTarget": "coder.event.v1"
+        }),
+    );
+    metadata
+}
+
+fn codex_backend_profile() -> BackendProfile {
+    BackendProfile {
+        name: String::from("openai-codex-subscription"),
+        kind: BackendKind::OpenAiCodexSubscription,
+        base_url: String::from("https://chatgpt.com/backend-api/codex"),
+        model: String::from("gpt-5.4"),
+        reasoning_level: None,
+        service_tier: None,
+        api_key_env: String::from("PROBE_OPENAI_API_KEY"),
+        timeout_secs: 600,
+        attach_mode: ServerAttachMode::AttachToExisting,
+        prefix_cache_mode: PrefixCacheMode::BackendDefault,
+        control_plane: None,
+        psionic_mesh: None,
+    }
+}
+
+fn assert_no_secret_payload(value: &Value) {
+    let serialized = serde_json::to_string(value).expect("serialize value");
+
+    for forbidden in [
+        "ghp_",
+        "Bearer ",
+        "Authorization",
+        "/Users/",
+        ".env",
+        ".secrets",
+        "refresh_token",
+        "rawProbeTranscript",
+        "unbounded output",
+    ] {
+        assert!(
+            !serialized.contains(forbidden),
+            "website-safe fixture leaked {forbidden}"
+        );
+    }
+}

--- a/docs/101-openagents-coder-runtime-adapter.md
+++ b/docs/101-openagents-coder-runtime-adapter.md
@@ -1,0 +1,140 @@
+# OpenAgents Coder Runtime Adapter Compatibility
+
+Issue: [#142](https://github.com/OpenAgentsInc/probe/issues/142)  
+Autopilot adapter:
+[#199](https://github.com/OpenAgentsInc/autopilot3/issues/199)  
+Autopilot tracker:
+[#200](https://github.com/OpenAgentsInc/autopilot3/issues/200)
+
+Probe can be used as a hosted OpenAgents Coder runtime behind the same Coder
+job/event/approval contract as the Codex app-server, Flue, local companion, and
+future runtime adapters. Probe remains the runtime boundary. Autopilot remains
+the product boundary that owns workspaces, Coder deployments, Coder jobs,
+approvals, evidence, receipts, and user-visible API responses.
+
+## Stable Contract
+
+Hosted Probe should expose these Probe-owned contracts to Autopilot:
+
+- `probe.managed_runtime.v1` for start, resume, replay, cancel, resolve
+  approval, heartbeat, child-session, transcript-ref, and artifact-ref control.
+- `probe.website_event.v1` for product-safe event streaming into Autopilot's
+  `coder.event.v1` rows.
+- `probe.managed_environment.v1` for hosted worker advertisement, capability
+  matching, environment provenance, and incompatibility reasons.
+- `probe.forge_worker.verification_pack_report` when Autopilot or Forge needs
+  release-gate evidence for hosted worker identity and sync state.
+
+Autopilot should treat hosted Probe as one runtime adapter behind Coder. It
+should not depend on Probe internals, raw session transcripts, local filesystem
+paths, model-provider secrets, or unbounded tool output.
+Compatibility shorthand: raw Probe transcripts stay runtime-local unless Probe
+exports an explicit redacted artifact ref.
+
+## Operation Mapping
+
+| Coder adapter need | Probe contract |
+| --- | --- |
+| Start a Coder job | `ManagedRuntimeRequest::StartSession` |
+| Attach or resume a job | `ManagedRuntimeRequest::ResumeSession` |
+| Replay events after a cursor | `ManagedRuntimeRequest::ReplayEvents` |
+| Cancel or interrupt work | `ManagedRuntimeRequest::CancelSession` or `InterruptSession` |
+| Resolve a pending approval | `ManagedRuntimeRequest::ResolveApproval` |
+| Track hosted worker liveness | `ManagedRuntimeRequest::Heartbeat` |
+| Spawn bounded child sessions | `ManagedRuntimeRequest::RecordChildSession` |
+| Return evidence pointers | `ManagedRuntimeArtifactRef` and website artifact refs |
+
+Every request should carry Autopilot correlation in
+`ManagedRuntimeCorrelation`: `requestId`, `workspace`, `managedRunId`,
+`managedSessionId`, `managedEnvironmentId`, `workOrderId`, optional schedule
+fields, parent/child Probe session ids, and the Coder job id in metadata.
+
+## Website Event Mapping
+
+Autopilot can map `probe.website_event.v1` into `coder.event.v1` with this
+lossless product-safe projection:
+
+| Probe website event | Coder event |
+| --- | --- |
+| `run_started` | `job.started` |
+| `text_delta` | `assistant.delta` |
+| `tool_call_started` | `tool.started` |
+| `tool_call_completed` | `tool.completed` |
+| `approval_requested` | `approval.requested` |
+| `approval_resolved` | `approval.resolved` |
+| `child_session_started` | `child_session.started` |
+| `child_session_updated` | `child_session.updated` |
+| `artifact_ref` | `artifact.ref` |
+| `runtime_progress` | `runtime.progress` |
+| `run_completed` | `job.completed` |
+| `run_failed` | `job.failed` |
+| `run_cancelled` | `job.canceled` |
+
+Payloads must stay bounded and redacted. Store stable hashes, counts, labels,
+risk classes, approval states, status summaries, and artifact refs. Do not
+store raw tool arguments, raw tool output blobs, terminal logs, model-provider
+tokens, browser cookies, refresh tokens, clone credentials, local paths, or raw
+Probe transcripts in Autopilot product state.
+
+## Auth State
+
+Probe-owned Codex subscription auth should be exposed to Autopilot only as
+product-safe status:
+
+- `available`, `reauth_required`, `rate_limited`, `disabled`, or `unknown`;
+- non-secret account label or route id;
+- last checked timestamp;
+- usage or limit posture when Probe can summarize it safely;
+- retry/reauth instructions that do not include raw paths or tokens.
+
+Raw auth files, session cookies, refresh tokens, model-provider keys, and
+subscription account payloads stay runtime-local to Probe or its worker secret
+store. Autopilot should never persist them in Coder jobs, Coder deployments,
+receipts, API responses, or workspace audit events.
+
+## Hosted Worker Identity And Policy
+
+Hosted Probe workers should advertise:
+
+- worker id, pool id, deployment revision, region, and provider;
+- execution host kind and attach transport;
+- repository checkout and sync capability;
+- tool allowlist and approval policy;
+- child-session limits, timeout limits, and artifact limits;
+- verification-pack artifact refs;
+- environment compatibility reasons when a Coder deployment cannot run.
+
+Autopilot should dispatch to hosted Probe only when the advertisement satisfies
+the Coder deployment's repository, runtime, approval, artifact, and child
+session constraints. If matching fails, return a Coder receipt with the
+product-safe incompatibility reason.
+
+## Minimal Smoke
+
+A hosted Probe Coder smoke should:
+
+1. send a `StartSession` request with Coder job/deployment metadata and an
+   idempotency key;
+2. receive an accepted managed session ref and transcript artifact ref;
+3. stream a `probe.website_event.v1` batch with `run_started`, at least one
+   progress or tool event, optional approval, artifact ref, and terminal event;
+4. replay the same events after a cursor;
+5. resolve one approval if present;
+6. cancel or interrupt the smoke session and receive a terminal projection;
+7. verify that website-safe events contain no provider tokens, local paths, raw
+   tool payloads, or unbounded output;
+8. attach the redacted event batch and verification-pack refs to the Autopilot
+   Coder receipt.
+
+The fixture-backed protocol test in
+`crates/probe-protocol/tests/coder_runtime_adapter_contract.rs` is the current
+minimal smoke path. A live worker smoke can replace the fixture once hosted
+Probe is selected as the active Coder runtime worker host.
+
+## Current Missing Fields
+
+No blocking managed-runtime fields are missing for the Autopilot Coder MVP.
+Autopilot can carry Coder-specific ids in `ManagedRuntimeCorrelation` and
+`ManagedSessionStartRequest.metadata`. If future Coder receipts need richer
+fields, add them as product-safe metadata first and promote them into typed
+Probe protocol only after a second consumer needs the same field.

--- a/docs/README.md
+++ b/docs/README.md
@@ -355,3 +355,8 @@ This folder holds technical planning docs for the Probe runtime.
   - one-level managed child-session delegation, parent-scoped child drilldown,
     child summaries and traces for API/UI, and parent-interrupt propagation to
     queued or approval-paused child work
+- `101-openagents-coder-runtime-adapter.md`
+  - OpenAgents Coder compatibility note for hosted Probe as one Autopilot Coder
+    runtime adapter, including managed-runtime operations, website-safe event
+    mapping, auth boundaries, hosted worker identity, child-session constraints,
+    and the fixture-backed minimal smoke path


### PR DESCRIPTION
## Summary
- add the OpenAgents Coder compatibility note for hosted Probe as a Coder runtime adapter behind Autopilot-owned jobs/events/approvals/evidence/receipts
- document managed-runtime operation mapping, website-safe event mapping to `coder.event.v1`, auth-state boundaries, hosted worker identity, and the minimal smoke path
- add a probe-protocol fixture test for Coder-style managed runtime start requests and website-safe event mapping without secret/raw runtime payload leakage

## Validation
- `cargo fmt --all`
- `cargo test -p probe-protocol --test coder_runtime_adapter_contract`
- `cargo test -p probe-protocol`
- `cargo test -p probe-cli --test cli_regressions accept_process_emits_stable_report_shape -- --nocapture`
- `./probe-dev fmt-check`
- `./probe-dev check`
- `git diff --check`

Note: I attempted `./probe-dev pr-fast`; the workspace-wide `cargo test` lane repeatedly hit the existing `accept_process_emits_stable_report_shape` mock-backend flake when run with the full `probe-cli` regression binary, while the same failing regression passed when rerun directly. The touched crate/docs path is covered by the protocol tests above.

Closes #142
